### PR TITLE
Log error returned by getTimeline()

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,10 +64,10 @@ func isWhitelisted(id int64) bool {
 
 func deleteFromTimeline(api *anaconda.TwitterApi, ageLimit time.Duration) {
 	timeline, err := getTimeline(api)
-
 	if err != nil {
-		log.Print("could not get timeline")
+		log.Print("could not get timeline", err)
 	}
+
 	for _, t := range timeline {
 		createdTime, err := t.CreatedAtTime()
 		if err != nil {


### PR DESCRIPTION
This pull request prints the error returned by the call to `getTimeline()`.

These errors include details from failed calls to the Twitter API (e.g. expired or invalid tokens). If they are not printed as part of the log statements the cause of issues can be hard to track down.